### PR TITLE
fix : add fallback for createImageBitmap and improve resource cleanup

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -243,7 +243,7 @@ const UI = (function () {
 
     try {
       // 古いリソースを解放
-      if (state.originalBitmap) {
+      if (state.originalBitmap && typeof state.originalBitmap.close === 'function') {
         state.originalBitmap.close();
       }
       if (state.previewUrl && state.previewUrl.startsWith('blob:')) {
@@ -742,7 +742,7 @@ const UI = (function () {
 
   function handleReset() {
     // 状態リセット
-    if (state.originalBitmap) {
+    if (state.originalBitmap && typeof state.originalBitmap.close === 'function') {
       state.originalBitmap.close();
     }
     if (state.previewUrl && state.previewUrl.startsWith('blob:')) {


### PR DESCRIPTION
This pull request improves the robustness of image loading and resource cleanup in the application. The main changes include adding a multi-level fallback mechanism for image loading in environments where certain APIs are not supported, and ensuring that resources are only released if they support the necessary methods.

**Image loading robustness:**
- Added a fallback to load images using an `HTMLImageElement` if `createImageBitmap` fails, improving compatibility with browsers that do not support the `imageOrientation` option or `createImageBitmap` itself.
- Implemented the `loadImageElementFromFile` function to handle loading images as DOM elements when other methods are unavailable.

**Resource cleanup improvements:**
- Updated checks before calling `close()` on `state.originalBitmap` to ensure the method exists, preventing errors when the bitmap does not support `close()`. [[1]](diffhunk://#diff-f2e0e6d1424d62935e6aac986cdca3b8bfc33333b452b3015494510fecced163L246-R246) [[2]](diffhunk://#diff-f2e0e6d1424d62935e6aac986cdca3b8bfc33333b452b3015494510fecced163L745-R745)